### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-##MobileGit  
+## MobileGit  
 This is a github application for iOS, it's written in Javascript using angularJS and ionic framework
 
-###Getting things running
+### Getting things running
 <code>npm install</code>  
 <code>bower install</code>  
 <code>gulp</code>  


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
